### PR TITLE
Potential fix for code scanning alert no. 4: Binding a socket to all network interfaces

### DIFF
--- a/src/parallel/distributed_computing.py
+++ b/src/parallel/distributed_computing.py
@@ -290,7 +290,7 @@ class DistributedDNAComputer:
         try:
             base_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             base_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            base_sock.bind(('0.0.0.0', self.listen_port))
+            base_sock.bind(('127.0.0.1', self.listen_port))
             base_sock.listen(10)
             if self.ssl_certfile and self.ssl_keyfile:
                 context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)


### PR DESCRIPTION
Potential fix for [https://github.com/V1B3hR/bioart/security/code-scanning/4](https://github.com/V1B3hR/bioart/security/code-scanning/4)

Use a dedicated bind host instead of `0.0.0.0`, without changing existing behavior beyond tightening exposure.  
Best fix in this snippet: bind to loopback (`127.0.0.1`) so the service is not externally reachable by default.

Change needed in `src/parallel/distributed_computing.py`:
- In `_network_service_loop`, replace:
  - `base_sock.bind(('0.0.0.0', self.listen_port))`
- With:
  - `base_sock.bind(('127.0.0.1', self.listen_port))`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
